### PR TITLE
Handle non-JSON calibration responses

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,15 +64,17 @@ async function groqChat(messages){
   const t=await r.text();
   if(!r.ok) throw new Error(t);
   const j=JSON.parse(t);
-  const choice=j.choices?.[0]??j.choices?.[1];
-  return choice?.message?.content?[choice.message.content]:[];
+  const contents=(j.choices||[]).map(c=>c.message?.content).filter(Boolean);
+  return contents;
 }
 async function nextQuestion(){
   try{
     started=true;
     const prompt=`Persona:\n${persona.text}\n\nGenerate one multiple-choice question to refine this persona. Use varied everyday topics. Return JSON {question:string, answers:string[], personaIndex:number} where personaIndex is which answer the persona would pick.`;
     const [out]=await groqChat([{role:'user',content:prompt}]);
-    const qa=JSON.parse(out);
+    const match=out.match(/\{[\s\S]*\}/);
+    if(!match) throw new Error('Model did not return JSON');
+    const qa=JSON.parse(match[0]);
     currentQA=qa;
     document.getElementById('qtext').textContent=qa.question;
     const answersDiv=document.getElementById('answers');


### PR DESCRIPTION
## Summary
- ensure calibration step extracts JSON from model output before parsing
- collect message content from Groq API chat responses reliably

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b93e279c448328a086aeb8525b540e