### PR TITLE
Fix JSON parse errors in calibration

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,10 @@ async function nextQuestion(){
     const [out]=await groqChat([{role:'user',content:prompt}]);
     const match=out.match(/\{[\s\S]*\}/);
     if(!match) throw new Error('Model did not return JSON');
-    const qa=JSON.parse(match[0]);
+    const cleaned=match[0]
+      .replace(/\/\/.*$/gm,'')
+      .replace(/\/\*[\s\S]*?\*\//g,'');
+    const qa=JSON.parse(cleaned);
     currentQA=qa;
     document.getElementById('qtext').textContent=qa.question;
     const answersDiv=document.getElementById('answers');


### PR DESCRIPTION
## Summary
- strip line and block comments from model output before JSON parsing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9601b60388328816615853a3b8a95