### PR TITLE
Revamp UI with Bootstrap chat styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,71 +6,69 @@
 <title>Persona Trainer PWA</title>
 <link rel="manifest" href="manifest.webmanifest">
 <link rel="icon" href="icon.svg" type="image/svg+xml">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <meta name="theme-color" content="#ffffff" />
 <style>
 body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:0;line-height:1.4}
-nav{display:flex;gap:4px;background:#eee;padding:8px;position:sticky;top:0;z-index:1}
-nav button{flex:1;padding:6px 0;border:none;background:#ddd;border-radius:6px;cursor:pointer}
 .screen{display:none;padding:10px}
 .screen.active{display:block}
-button{padding:6px 12px;margin:4px;border-radius:6px;border:1px solid #888;background:#fff;cursor:pointer}
-.history{max-height:60vh;overflow-y:auto;border:1px solid #ccc;border-radius:8px;padding:6px;margin-bottom:8px}
-.message{margin:4px 0;padding:6px;border-radius:6px}
-.message.user{background:#e0f0ff}
-.message.bot{background:#f0e0ff}
-.answer{display:block;margin:6px 0;padding:8px;border:1px solid #ccc;border-radius:8px;cursor:pointer}
+#history{max-height:60vh;overflow-y:auto;padding:6px;margin-bottom:8px;border:1px solid #ccc;border-radius:8px;background:#f8f9fa}
+.chat-row{display:flex;margin-bottom:8px}
+.chat-bubble{padding:8px 12px;border-radius:20px;max-width:80%}
+.chat-bubble.user{margin-left:auto;background:#0d6efd;color:#fff}
+.chat-bubble.bot{margin-right:auto;background:#e9ecef}
+.answer{cursor:pointer}
 .answer.persona{border-color:#0a0;background:#e0ffe0}
 .progress-container{width:100%;height:10px;background:#ddd;border-radius:5px;margin:8px 0}
 .progress-bar{height:100%;width:0%;background:red;border-radius:5px}
-@media(min-width:600px){nav{justify-content:flex-start}nav button{flex:none}}
 pre{background:#f9f9f9;padding:8px;border:1px solid #eee;border-radius:6px;white-space:pre-wrap}
 </style>
 </head>
 <body>
-<nav id="tabs">
-<button data-target="main">Chat</button>
-<button data-target="learn">Learn</button>
-<button data-target="persona">Persona</button>
-<button data-target="settings">Settings</button>
+<nav class="nav nav-pills nav-fill sticky-top bg-light p-2" id="tabs">
+<button class="nav-link active" data-target="main">Chat</button>
+<button class="nav-link" data-target="learn">Learn</button>
+<button class="nav-link" data-target="persona">Persona</button>
+<button class="nav-link" data-target="settings">Settings</button>
 </nav>
-<section id="main" class="screen active">
+<section id="main" class="screen active container my-3">
 <h2>Chat</h2>
-<div id="history" class="history"></div>
-<div id="samples">
-<button class="sample">Should I buy a house?</button>
-<button class="sample">Am I ready for a long term relationship?</button>
-<button class="sample">Should I change careers?</button>
+<div id="history"></div>
+<div id="samples" class="mb-2">
+<button class="sample btn btn-outline-secondary btn-sm me-1 mb-1">Should I buy a house?</button>
+<button class="sample btn btn-outline-secondary btn-sm me-1 mb-1">Am I ready for a long term relationship?</button>
+<button class="sample btn btn-outline-secondary btn-sm mb-1">Should I change careers?</button>
 </div>
-<textarea id="chatInput" rows="2" style="width:100%" placeholder="Ask something..."></textarea><br>
-<button id="send">Send</button>
-<button id="clearChat">Clear</button>
+<textarea id="chatInput" rows="2" class="form-control mb-2" placeholder="Ask something..."></textarea>
+<button id="send" class="btn btn-primary me-2">Send</button>
+<button id="clearChat" class="btn btn-secondary">Clear</button>
 </section>
-<section id="learn" class="screen">
+<section id="learn" class="screen container my-3">
 <h2>Learning</h2>
 <div class="progress-container"><div id="progress" class="progress-bar"></div></div>
 <div id="progressText">0%</div>
 <div id="qtext">Enter an API key to begin.</div>
-<div id="answers"></div>
+<div id="answers" class="list-group"></div>
 </section>
-<section id="persona" class="screen">
+<section id="persona" class="screen container my-3">
 <h2>Persona</h2>
 <pre id="personaPreview"></pre>
-<textarea id="guidanceBox" rows="3" style="width:100%"></textarea><br>
-<button id="updateGuidance">Update Guidance</button>
+<textarea id="guidanceBox" rows="3" class="form-control mb-2"></textarea>
+<button id="updateGuidance" class="btn btn-primary mb-2">Update Guidance</button>
 <div>
-<button id="savePersona">Save</button>
-<button id="loadPersona">Load</button>
+<button id="savePersona" class="btn btn-secondary me-2">Save</button>
+<button id="loadPersona" class="btn btn-secondary me-2">Load</button>
 <input type="file" id="loadInput" style="display:none">
-<button id="clearPersona">Clear</button>
+<button id="clearPersona" class="btn btn-danger">Clear</button>
 </div>
 </section>
-<section id="settings" class="screen">
+<section id="settings" class="screen container my-3">
 <h2>Settings</h2>
-<label>API key <input id="apikey" style="width:260px"></label><br>
-<label>Service URL <input id="service" style="width:260px"></label><br>
-<button id="saveSettings">Save</button>
-<button id="clearStorage">Clear Storage</button>
-<button id="refresh">Refresh</button>
+<div class="mb-2"><label class="form-label">API key <input id="apikey" class="form-control"></label></div>
+<div class="mb-2"><label class="form-label">Service URL <input id="service" class="form-control"></label></div>
+<button id="saveSettings" class="btn btn-primary me-2">Save</button>
+<button id="clearStorage" class="btn btn-secondary me-2">Clear Storage</button>
+<button id="refresh" class="btn btn-warning">Refresh</button>
 </section>
 <script>
 if('serviceWorker' in navigator){navigator.serviceWorker.register('sw.js');}
@@ -103,15 +101,16 @@ function updateProgress(){const answered=Object.values(coverage).reduce((a,b)=>a
 updateProgress();
 async function groqChat(messages){const key=localStorage.getItem('api_key')||localStorage.getItem('groq_key');const svc=localStorage.getItem('service')||'https://api.groq.com/openai/v1/chat/completions';if(!key) throw new Error('Missing API key');const r=await fetch(svc,{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+key},body:JSON.stringify({model:'llama-3.1-8b-instant',temperature:0.7,messages})});const t=await r.text();if(!r.ok) throw new Error(t);const j=JSON.parse(t);const contents=(j.choices||[]).map(c=>c.message?.content).filter(Boolean);return contents;}
 function showRetry(target,action){target.innerHTML='';const b=document.createElement('button');b.textContent='Retry';b.onclick=action;target.appendChild(b);}
-async function nextQuestion(){try{started=true;const cat=leastCovered();currentCategory=cat.name;const prompt=`Persona:\n${persona.text}\nGuidance:\n${guidanceText}\n\nGenerate one short, simple multiple-choice question (under 20 words) to refine this persona's ${cat.name} (${cat.desc}). Use a different everyday topic each time. Return JSON {question:string, answers:string[], personaIndex:number} where the question and answers are brief and personaIndex is which answer the persona would choose.`;const [out]=await groqChat([{role:'user',content:prompt}]);const match=out.match(/\{[\s\S]*\}/);if(!match) throw new Error('Model did not return JSON');const cleaned=match[0].replace(/\/\/.*$/gm,'').replace(/\/\*[\s\S]*?\*\//g,'');const qa=JSON.parse(cleaned);currentQA=qa;document.getElementById('qtext').textContent=qa.question;const answersDiv=document.getElementById('answers');answersDiv.innerHTML='';qa.answers.forEach((ans,i)=>{const d=document.createElement('div');d.textContent=ans;d.className='answer'+(i===qa.personaIndex?' persona':'');d.onclick=()=>selectAnswer(i);answersDiv.appendChild(d);});}catch(e){document.getElementById('qtext').textContent='';showRetry(document.getElementById('answers'),nextQuestion);}}
+async function nextQuestion(){try{started=true;const cat=leastCovered();currentCategory=cat.name;const prompt=`Persona:\n${persona.text}\nGuidance:\n${guidanceText}\n\nGenerate one short, simple multiple-choice question (under 20 words) to refine this persona's ${cat.name} (${cat.desc}). Use a different everyday topic each time. Return JSON {question:string, answers:string[], personaIndex:number} where the question and answers are brief and personaIndex is which answer the persona would choose.`;const [out]=await groqChat([{role:'user',content:prompt}]);const match=out.match(/\{[\s\S]*\}/);if(!match) throw new Error('Model did not return JSON');const cleaned=match[0].replace(/\/\/.*$/gm,'').replace(/\/\*[\s\S]*?\*\//g,'');const qa=JSON.parse(cleaned);currentQA=qa;document.getElementById('qtext').textContent=qa.question;const answersDiv=document.getElementById('answers');answersDiv.innerHTML='';qa.answers.forEach((ans,i)=>{const d=document.createElement('div');d.textContent=ans;d.className='list-group-item list-group-item-action answer'+(i===qa.personaIndex?' persona':'');d.onclick=()=>selectAnswer(i);answersDiv.appendChild(d);});}catch(e){document.getElementById('qtext').textContent='';showRetry(document.getElementById('answers'),nextQuestion);}}
 async function selectAnswer(idx){const qa=currentQA;const ans=qa.answers[idx];const answersDiv=document.getElementById('answers');try{const prompt=`Existing persona:\n${persona.text}\nGuidance:\n${guidanceText}\nQuestion:${qa.question}\nCategory:${currentCategory}\nAnswers:${qa.answers.join(' | ')}\nUser selected:${ans}. Revise the persona incrementally so it leans toward this option while avoiding assumptions about name, gender, or age. Keep the description brief and general. Reply with the updated persona text only.`;const [out]=await groqChat([{role:'user',content:prompt}]);persona.text=out.trim();coverage[currentCategory]=(coverage[currentCategory]||0)+1;localStorage.setItem('coverage',JSON.stringify(coverage));updatePersona();nextQuestion();}catch(e){showRetry(answersDiv,()=>selectAnswer(idx));}}
 const chatInput=document.getElementById('chatInput');const historyDiv=document.getElementById('history');
-function renderChat(){historyDiv.innerHTML='';chatHistory.forEach(m=>{const d=document.createElement('div');d.className='message '+(m.role==='user'?'user':'bot');d.textContent=m.content;historyDiv.appendChild(d);});historyDiv.scrollTop=historyDiv.scrollHeight;}
+function renderChat(){historyDiv.innerHTML='';chatHistory.forEach(m=>{const row=document.createElement('div');row.className='chat-row';const bubble=document.createElement('div');bubble.className='chat-bubble '+(m.role==='user'?'user':'bot');bubble.textContent=m.content;row.appendChild(bubble);historyDiv.appendChild(row);});historyDiv.scrollTop=historyDiv.scrollHeight;}
 async function sendChat(){const q=chatInput.value.trim();if(!q)return;chatHistory.push({role:'user',content:q});renderChat();chatInput.value='';try{const msgs=[{role:'system',content:`You are the following persona:\n${persona.text}\nGuidance:\n${guidanceText}\nAnswer strictly as this persona. Be concise and give a clear, direct reply in one short sentence.`},...chatHistory];const [out]=await groqChat(msgs);chatHistory.push({role:'assistant',content:out.trim()});renderChat();}catch(e){chatHistory.push({role:'assistant',content:'Error'});renderChat();}}
 document.getElementById('send').onclick=sendChat;document.getElementById('clearChat').onclick=()=>{chatHistory=[];renderChat();};document.querySelectorAll('.sample').forEach(b=>b.onclick=()=>{chatInput.value=b.textContent;sendChat();});
 let currentScreen='main';
-function showScreen(id){currentScreen=id;document.querySelectorAll('.screen').forEach(s=>s.classList.remove('active'));document.getElementById(id).classList.add('active');if(id==='learn'&&!started&&(localStorage.getItem('api_key')||localStorage.getItem('groq_key')))nextQuestion();}
-document.querySelectorAll('#tabs button').forEach(btn=>{btn.onclick=()=>showScreen(btn.dataset.target);});
+function showScreen(id){currentScreen=id;document.querySelectorAll('.screen').forEach(s=>s.classList.remove('active'));document.getElementById(id).classList.add('active');document.querySelectorAll('#tabs .nav-link').forEach(b=>b.classList.remove('active'));document.querySelector(`#tabs [data-target="${id}"]`).classList.add('active');if(id==='learn'&&!started&&(localStorage.getItem('api_key')||localStorage.getItem('groq_key')))nextQuestion();}
+document.querySelectorAll('#tabs .nav-link').forEach(btn=>{btn.onclick=()=>showScreen(btn.dataset.target);});
 </script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate Bootstrap for responsive layout and modern styling
- redesign chat with left/right bubbles and polished nav/buttons
- style learning answers with list groups for a native feel

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99e8e140483289296e6e75b655a13