### PR TITLE
Improve dynamic persona question generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,14 +94,56 @@ document.getElementById('savePersona').onclick=()=>{const data=JSON.stringify({p
 document.getElementById('loadPersona').onclick=()=>document.getElementById('loadInput').click();
 document.getElementById('loadInput').onchange=e=>{const file=e.target.files[0];if(!file)return;const reader=new FileReader();reader.onload=ev=>{try{const obj=JSON.parse(ev.target.result);persona.text=obj.persona||defaultPersona;guidanceText=obj.guidance||'';coverage={};localStorage.removeItem('coverage');updatePersona();}catch(err){console.error(err);}};reader.readAsText(file);};
 document.getElementById('clearPersona').onclick=()=>{persona.text=defaultPersona;guidanceText='';coverage={};localStorage.removeItem('coverage');updatePersona();};
-const categories=[{name:'Interpersonal Style',desc:'how they relate to others'},{name:'Cognitive Preferences',desc:'how they approach problems'},{name:'Emotional Patterns',desc:'how they react to stress and feelings'},{name:'Motivation & Values',desc:'what drives their decisions'},{name:'Self-Discipline & Reliability',desc:'organization and follow-through'},{name:'Adaptability & Risk',desc:'openness to change and risk tolerance'},{name:'Identity & Self-Perception',desc:'self-confidence and awareness'}];
+const categories=[
+  {name:'Likes & Dislikes',desc:'tastes in activities or food'},
+  {name:'Politics & Society',desc:'political and social outlook'},
+  {name:'Geography & Climate',desc:'preferred places and weather'},
+  {name:'Energy & Routine',desc:'daily energy and lifestyle'},
+  {name:'Aspirations & Goals',desc:'career or life ambitions'},
+  {name:'Psychological Traits',desc:'thinking patterns and behaviour'},
+  {name:'Culture & Arts',desc:'music, media and art interests'},
+  {name:'Relationships & Community',desc:'friendships and social ties'},
+  {name:'Work & Productivity',desc:'discipline and work style'},
+  {name:'Decision Making & Values',desc:'how choices and priorities form'},
+  {name:'Emotions & Coping',desc:'responses to stress or loss'},
+  {name:'Technology & Innovation',desc:'attitude toward new tech'},
+  {name:'Spare Time & Hobbies',desc:'weekend and leisure pursuits'},
+  {name:'Financial Outlook',desc:'saving, spending or investing'},
+  {name:'Travel & Adventure',desc:'motivation for exploring new places'}
+];
 function leastCovered(){let min=Infinity,opts=[];categories.forEach(c=>{const v=coverage[c.name]||0;if(v<min){min=v;opts=[c];}else if(v===min){opts.push(c);}});return opts[Math.floor(Math.random()*opts.length)];}
 let currentQA=null;let currentCategory=null;let started=false;const progressBar=document.getElementById('progress');const progressText=document.getElementById('progressText');
 function updateProgress(){const answered=Object.values(coverage).reduce((a,b)=>a+b,0);const pct=Math.round(100*(1-Math.exp(-answered/5)));progressBar.style.width=pct+'%';progressBar.style.backgroundColor=answered<5?'red':answered<10?'orange':'green';progressText.textContent=pct+'%';}
 updateProgress();
 async function groqChat(messages){const key=localStorage.getItem('api_key')||localStorage.getItem('groq_key');const svc=localStorage.getItem('service')||'https://api.groq.com/openai/v1/chat/completions';if(!key) throw new Error('Missing API key');const r=await fetch(svc,{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+key},body:JSON.stringify({model:'llama-3.1-8b-instant',temperature:0.7,messages})});const t=await r.text();if(!r.ok) throw new Error(t);const j=JSON.parse(t);const contents=(j.choices||[]).map(c=>c.message?.content).filter(Boolean);return contents;}
 function showRetry(target,action){target.innerHTML='';const b=document.createElement('button');b.textContent='Retry';b.onclick=action;target.appendChild(b);}
-async function nextQuestion(){try{started=true;const cat=leastCovered();currentCategory=cat.name;const prompt=`Persona:\n${persona.text}\nGuidance:\n${guidanceText}\n\nGenerate one short, simple multiple-choice question (under 20 words) to refine this persona's ${cat.name} (${cat.desc}). Use a different everyday topic each time. Return JSON {question:string, answers:string[], personaIndex:number} where the question and answers are brief and personaIndex is which answer the persona would choose.`;const [out]=await groqChat([{role:'user',content:prompt}]);const match=out.match(/\{[\s\S]*\}/);if(!match) throw new Error('Model did not return JSON');const cleaned=match[0].replace(/\/\/.*$/gm,'').replace(/\/\*[\s\S]*?\*\//g,'');const qa=JSON.parse(cleaned);currentQA=qa;document.getElementById('qtext').textContent=qa.question;const answersDiv=document.getElementById('answers');answersDiv.innerHTML='';qa.answers.forEach((ans,i)=>{const d=document.createElement('div');d.textContent=ans;d.className='list-group-item list-group-item-action answer'+(i===qa.personaIndex?' persona':'');d.onclick=()=>selectAnswer(i);answersDiv.appendChild(d);});}catch(e){document.getElementById('qtext').textContent='';showRetry(document.getElementById('answers'),nextQuestion);}}
+async function nextQuestion(){
+  try{
+    started=true;
+    const cat=leastCovered();
+    currentCategory=cat.name;
+    const prompt=`Persona:\n${persona.text}\nGuidance:\n${guidanceText}\n\nGenerate one concise multiple-choice question (<=15 words) about this persona's ${cat.name} (${cat.desc}). Provide up to four brief answers (<=6 words) covering distinct viewpoints. Avoid prejudice, race or sexism, and only repeat a topic to clarify ambiguity. Return JSON {question:string, answers:string[], personaIndex:number}.`;
+    const [out]=await groqChat([{role:'user',content:prompt}]);
+    const match=out.match(/\{[\s\S]*\}/);
+    if(!match) throw new Error('Model did not return JSON');
+    const cleaned=match[0].replace(/\/\/.*$/gm,'').replace(/\/\*[\s\S]*?\*\//g,'');
+    const qa=JSON.parse(cleaned);
+    currentQA=qa;
+    document.getElementById('qtext').textContent=qa.question;
+    const answersDiv=document.getElementById('answers');
+    answersDiv.innerHTML='';
+    qa.answers.forEach((ans,i)=>{
+      const d=document.createElement('div');
+      d.textContent=ans;
+      d.className='list-group-item list-group-item-action answer'+(i===qa.personaIndex?' persona':'');
+      d.onclick=()=>selectAnswer(i);
+      answersDiv.appendChild(d);
+    });
+  }catch(e){
+    document.getElementById('qtext').textContent='';
+    showRetry(document.getElementById('answers'),nextQuestion);
+  }
+}
 async function selectAnswer(idx){const qa=currentQA;const ans=qa.answers[idx];const answersDiv=document.getElementById('answers');try{const prompt=`Existing persona:\n${persona.text}\nGuidance:\n${guidanceText}\nQuestion:${qa.question}\nCategory:${currentCategory}\nAnswers:${qa.answers.join(' | ')}\nUser selected:${ans}. Revise the persona incrementally so it leans toward this option while avoiding assumptions about name, gender, or age. Keep the description brief and general. Reply with the updated persona text only.`;const [out]=await groqChat([{role:'user',content:prompt}]);persona.text=out.trim();coverage[currentCategory]=(coverage[currentCategory]||0)+1;localStorage.setItem('coverage',JSON.stringify(coverage));updatePersona();nextQuestion();}catch(e){showRetry(answersDiv,()=>selectAnswer(idx));}}
 const chatInput=document.getElementById('chatInput');const historyDiv=document.getElementById('history');
 function renderChat(){historyDiv.innerHTML='';chatHistory.forEach(m=>{const row=document.createElement('div');row.className='chat-row';const bubble=document.createElement('div');bubble.className='chat-bubble '+(m.role==='user'?'user':'bot');bubble.textContent=m.content;row.appendChild(bubble);historyDiv.appendChild(row);});historyDiv.scrollTop=historyDiv.scrollHeight;}


### PR DESCRIPTION
## Summary
- Broaden persona training categories to cover politics, culture, lifestyle, goals and more
- Refine question generation prompt for concise questions with diverse short answers and safety guards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a3f733488328bc527c62004750e8