### PR TITLE
Polish chat UI and enforce asexual persona rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,12 @@ body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:0;lin
 .screen.active{display:block}
 #history{max-height:60vh;overflow-y:auto;padding:6px;margin-bottom:8px;border:1px solid #ccc;border-radius:8px;background:#f8f9fa}
 .chat-row{display:flex;margin-bottom:8px}
-.chat-bubble{padding:8px 12px;border-radius:20px;max-width:80%}
-.chat-bubble.user{margin-left:auto;background:#0d6efd;color:#fff}
-.chat-bubble.bot{margin-right:auto;background:#e9ecef}
+.chat-bubble{padding:8px 12px;max-width:80%;border-radius:18px}
+.chat-bubble.user{margin-left:auto;background:#0b93f6;color:#fff;border-bottom-right-radius:4px}
+.chat-bubble.bot{margin-right:auto;background:#e5e5ea;border-bottom-left-radius:4px}
+#inputArea{display:flex;gap:8px;align-items:flex-end}
+#inputArea textarea{flex:1}
+#chatInput{border-radius:20px;resize:none;overflow:hidden}
 .answer{cursor:pointer}
 .answer.persona{border-color:#0a0;background:#e0ffe0}
 .progress-container{width:100%;height:10px;background:#ddd;border-radius:5px;margin:8px 0}
@@ -39,8 +42,10 @@ pre{background:#f9f9f9;padding:8px;border:1px solid #eee;border-radius:6px;white
 <button class="sample btn btn-outline-secondary btn-sm me-1 mb-1">Am I ready for a long term relationship?</button>
 <button class="sample btn btn-outline-secondary btn-sm mb-1">Should I change careers?</button>
 </div>
-<textarea id="chatInput" rows="2" class="form-control mb-2" placeholder="Ask something..."></textarea>
-<button id="send" class="btn btn-primary me-2">Send</button>
+<div id="inputArea" class="mb-2">
+  <textarea id="chatInput" rows="1" class="form-control" placeholder="Ask something..."></textarea>
+  <button id="send" class="btn btn-primary">Send</button>
+</div>
 <button id="clearChat" class="btn btn-secondary">Clear</button>
 </section>
 <section id="learn" class="screen container my-3">
@@ -72,8 +77,13 @@ pre{background:#f9f9f9;padding:8px;border:1px solid #eee;border-radius:6px;white
 </section>
 <script>
 if('serviceWorker' in navigator){navigator.serviceWorker.register('sw.js');}
-const defaultPersona='You are the digital twin of a real person.';
-let persona={text:localStorage.getItem('persona')||defaultPersona};
+const defaultPersona='You are the digital twin of a real person who is ruthlessly asexual and devoid of gender or racial attributes.';
+function optimizePersonaText(text){
+  const sentences=text.split(/[\.\n]+/).map(s=>s.trim()).filter(Boolean);
+  const unique=[...new Set(sentences)];
+  return unique.map(s=>s.replace(/\s+/g,' ')).join('. ')+'.';
+}
+let persona={text:optimizePersonaText(localStorage.getItem('persona')||defaultPersona)};
 let guidanceText=localStorage.getItem('guidance')||'';
 let coverage=JSON.parse(localStorage.getItem('coverage')||'{}');
 let chatHistory=[];
@@ -92,8 +102,8 @@ renderPersona();
 document.getElementById('updateGuidance').onclick=()=>{guidanceText=document.getElementById('guidanceBox').value.trim();updatePersona();};
 document.getElementById('savePersona').onclick=()=>{const data=JSON.stringify({persona:persona.text,guidance:guidanceText},null,2);const blob=new Blob([data],{type:'application/json'});const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='persona.json';a.click();URL.revokeObjectURL(a.href);};
 document.getElementById('loadPersona').onclick=()=>document.getElementById('loadInput').click();
-document.getElementById('loadInput').onchange=e=>{const file=e.target.files[0];if(!file)return;const reader=new FileReader();reader.onload=ev=>{try{const obj=JSON.parse(ev.target.result);persona.text=obj.persona||defaultPersona;guidanceText=obj.guidance||'';coverage={};localStorage.removeItem('coverage');updatePersona();}catch(err){console.error(err);}};reader.readAsText(file);};
-document.getElementById('clearPersona').onclick=()=>{persona.text=defaultPersona;guidanceText='';coverage={};localStorage.removeItem('coverage');updatePersona();};
+document.getElementById('loadInput').onchange=e=>{const file=e.target.files[0];if(!file)return;const reader=new FileReader();reader.onload=ev=>{try{const obj=JSON.parse(ev.target.result);persona.text=optimizePersonaText(obj.persona||defaultPersona);guidanceText=obj.guidance||'';coverage={};localStorage.removeItem('coverage');updatePersona();}catch(err){console.error(err);}};reader.readAsText(file);};
+document.getElementById('clearPersona').onclick=()=>{persona.text=optimizePersonaText(defaultPersona);guidanceText='';coverage={};localStorage.removeItem('coverage');updatePersona();};
 const categories=[
   {name:'Likes & Dislikes',desc:'tastes in activities or food'},
   {name:'Politics & Society',desc:'political and social outlook'},
@@ -122,7 +132,7 @@ async function nextQuestion(){
     started=true;
     const cat=leastCovered();
     currentCategory=cat.name;
-    const prompt=`Persona:\n${persona.text}\nGuidance:\n${guidanceText}\n\nGenerate one concise multiple-choice question (<=15 words) about this persona's ${cat.name} (${cat.desc}). Provide up to four brief answers (<=6 words) covering distinct viewpoints. Avoid prejudice, race or sexism, and only repeat a topic to clarify ambiguity. Return JSON {question:string, answers:string[], personaIndex:number}.`;
+    const prompt=`Persona:\n${persona.text}\nGuidance:\n${guidanceText}\n\nGenerate one concise multiple-choice question (<=15 words) about this persona's ${cat.name} (${cat.desc}). Provide two to four brief answers (<=6 words) that are mutually exclusive and collectively exhaustive. Do not include 'not applicable' or similar options and avoid any reference to gender, sexuality or race. Only repeat a topic to clarify ambiguity. Return JSON {question:string, answers:string[], personaIndex:number}.`;
     const [out]=await groqChat([{role:'user',content:prompt}]);
     const match=out.match(/\{[\s\S]*\}/);
     if(!match) throw new Error('Model did not return JSON');
@@ -144,10 +154,11 @@ async function nextQuestion(){
     showRetry(document.getElementById('answers'),nextQuestion);
   }
 }
-async function selectAnswer(idx){const qa=currentQA;const ans=qa.answers[idx];const answersDiv=document.getElementById('answers');try{const prompt=`Existing persona:\n${persona.text}\nGuidance:\n${guidanceText}\nQuestion:${qa.question}\nCategory:${currentCategory}\nAnswers:${qa.answers.join(' | ')}\nUser selected:${ans}. Revise the persona incrementally so it leans toward this option while avoiding assumptions about name, gender, or age. Keep the description brief and general. Reply with the updated persona text only.`;const [out]=await groqChat([{role:'user',content:prompt}]);persona.text=out.trim();coverage[currentCategory]=(coverage[currentCategory]||0)+1;localStorage.setItem('coverage',JSON.stringify(coverage));updatePersona();nextQuestion();}catch(e){showRetry(answersDiv,()=>selectAnswer(idx));}}
+async function selectAnswer(idx){const qa=currentQA;const ans=qa.answers[idx];const answersDiv=document.getElementById('answers');try{const prompt=`Existing persona:\n${persona.text}\nGuidance:\n${guidanceText}\nQuestion:${qa.question}\nCategory:${currentCategory}\nAnswers:${qa.answers.join(' | ')}\nUser selected:${ans}. Revise the persona incrementally so it leans toward this option while avoiding assumptions about name, gender, sexuality, or race. Ensure the persona remains ruthlessly asexual, concise and non-redundant. Reply with the updated persona text only.`;const [out]=await groqChat([{role:'user',content:prompt}]);persona.text=optimizePersonaText(out.trim());coverage[currentCategory]=(coverage[currentCategory]||0)+1;localStorage.setItem('coverage',JSON.stringify(coverage));updatePersona();nextQuestion();}catch(e){showRetry(answersDiv,()=>selectAnswer(idx));}}
 const chatInput=document.getElementById('chatInput');const historyDiv=document.getElementById('history');
+chatInput.addEventListener('input',()=>{chatInput.style.height='auto';chatInput.style.height=chatInput.scrollHeight+'px';});
 function renderChat(){historyDiv.innerHTML='';chatHistory.forEach(m=>{const row=document.createElement('div');row.className='chat-row';const bubble=document.createElement('div');bubble.className='chat-bubble '+(m.role==='user'?'user':'bot');bubble.textContent=m.content;row.appendChild(bubble);historyDiv.appendChild(row);});historyDiv.scrollTop=historyDiv.scrollHeight;}
-async function sendChat(){const q=chatInput.value.trim();if(!q)return;chatHistory.push({role:'user',content:q});renderChat();chatInput.value='';try{const msgs=[{role:'system',content:`You are the following persona:\n${persona.text}\nGuidance:\n${guidanceText}\nAnswer strictly as this persona. Be concise and give a clear, direct reply in one short sentence.`},...chatHistory];const [out]=await groqChat(msgs);chatHistory.push({role:'assistant',content:out.trim()});renderChat();}catch(e){chatHistory.push({role:'assistant',content:'Error'});renderChat();}}
+async function sendChat(){const q=chatInput.value.trim();if(!q)return;chatHistory.push({role:'user',content:q});renderChat();chatInput.value='';chatInput.style.height='auto';try{const msgs=[{role:'system',content:`You are the following persona:\n${persona.text}\nGuidance:\n${guidanceText}\nAnswer strictly as this persona while avoiding any mention of gender, sexuality or race. Be concise and give a clear, direct reply in one short sentence.`},...chatHistory];const [out]=await groqChat(msgs);chatHistory.push({role:'assistant',content:out.trim()});renderChat();}catch(e){chatHistory.push({role:'assistant',content:'Error'});renderChat();}}
 document.getElementById('send').onclick=sendChat;document.getElementById('clearChat').onclick=()=>{chatHistory=[];renderChat();};document.querySelectorAll('.sample').forEach(b=>b.onclick=()=>{chatInput.value=b.textContent;sendChat();});
 let currentScreen='main';
 function showScreen(id){currentScreen=id;document.querySelectorAll('.screen').forEach(s=>s.classList.remove('active'));document.getElementById(id).classList.add('active');document.querySelectorAll('#tabs .nav-link').forEach(b=>b.classList.remove('active'));document.querySelector(`#tabs [data-target="${id}"]`).classList.add('active');if(id==='learn'&&!started&&(localStorage.getItem('api_key')||localStorage.getItem('groq_key')))nextQuestion();}


### PR DESCRIPTION
## Summary
- Restyle chat screen to mimic iMessage, with curved expandable prompt area and inline send button
- Declare default persona as ruthlessly asexual and deduplicate persona text for brevity
- Strengthen learning prompts to avoid gender, sexuality or race and require exhaustive answer coverage

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4aaefe18832897e1930e07c05e29