### PR TITLE
Fix kv_namespaces array in wrangler config

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,7 +2,6 @@ name = "persona-trainer-worker"
 main = "worker.js"
 compatibility_date = "2024-10-01"
 
-[kv_namespaces]
-bindings = [
+kv_namespaces = [
   { binding = "KV", id = "YOUR_KV_NAMESPACE_ID" }
 ]


### PR DESCRIPTION
## Summary
- use array for `kv_namespaces` instead of `bindings` table

## Testing
- `npm test` (fails: enoent could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bc8ec79e7c83289b0900a669566532