### PR TITLE
Fix KV namespace binding for worker

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,5 +3,5 @@ main = "worker.js"
 compatibility_date = "2024-10-01"
 
 kv_namespaces = [
-  { binding = "atorvo", id = "KV" }
+  { binding = "KV", id = "$KV" }
 ]


### PR DESCRIPTION
## Summary
- bind worker KV namespace correctly using environment variable

## Testing
- `node --check worker.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bc937ed3088328834adcf861162161