### PR TITLE
fix: reference KV namespace via env variable

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,5 +3,5 @@ main = "worker.js"
 compatibility_date = "2024-10-01"
 
 kv_namespaces = [
-  { binding = "KV", id = "$KV" }
+  { binding = "KV", id = { env = "KV" } }
 ]


### PR DESCRIPTION
## Summary
- reference KV namespace ID from environment variable rather than literal `$KV`

## Testing
- `KV=placeholder npx wrangler deploy --dry-run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/wrangler)*

------
https://chatgpt.com/codex/tasks/task_e_68bc95f2888c832882c2eafec6852d6b