### PR TITLE
fix: use kv namespace block

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,7 @@ name = "persona-trainer-worker"
 main = "worker.js"
 compatibility_date = "2024-10-01"
 
-kv_namespaces = [
-  { binding = "KV", id = { env = "KV" } }
-]
+[[kv_namespaces]]
+binding = "KV"
+id = "$KV"
+


### PR DESCRIPTION
## Summary
- define KV namespace using dedicated table so id can be supplied via `KV` environment variable

## Testing
- `node --check worker.js`
- `KV=exampleKV npx wrangler deploy --dry-run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/wrangler)*

------
https://chatgpt.com/codex/tasks/task_e_68bc98233eb08328a3ae23faeb151a95