### PR TITLE
Add API endpoint tests and integrate into build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "twin1",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "twin1",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "twin1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "sw.js",
+  "scripts": {
+    "test": "node --test",
+    "build": "npm test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/worker.test.js
+++ b/worker.test.js
@@ -1,0 +1,57 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import worker from './worker.js';
+
+class MockKV {
+  constructor() { this.store = new Map(); }
+  async get(key) { return this.store.get(key); }
+  async put(key, value) { this.store.set(key, value); }
+}
+
+test('unauthorized request returns 401', async () => {
+  const req = new Request('http://example.com/api/profile');
+  const res = await worker.fetch(req, { KV: new MockKV() });
+  assert.equal(res.status, 401);
+});
+
+test('init assigns name and persona', async () => {
+  const kv = new MockKV();
+  await kv.put('groq-api-key', 'key');
+  const originalFetch = global.fetch;
+  global.fetch = async () => new Response(
+    JSON.stringify({ choices: [{ message: { content: 'Alex' } }] }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+  try {
+    const req = new Request('http://example.com/api/init', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer user1' }
+    });
+    const res = await worker.fetch(req, { KV: kv });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.name, 'Alex');
+    assert.equal(await kv.get('user1-name'), 'Alex');
+    assert.ok(await kv.get('user1-persona'));
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('profile returns stored data', async () => {
+  const kv = new MockKV();
+  await kv.put('user1-name', 'Jamie');
+  await kv.put('user1-persona', 'Test persona.');
+  await kv.put('user1-guidance', 'Be nice');
+  const req = new Request('http://example.com/api/profile', {
+    headers: { Authorization: 'Bearer user1' }
+  });
+  const res = await worker.fetch(req, { KV: kv });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepEqual(body, {
+    name: 'Jamie',
+    persona: 'Test persona.',
+    guidance: 'Be nice'
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,3 +6,6 @@ compatibility_date = "2024-10-01"
 #binding = "KV"
 #id = "$KV"
 
+
+[build]
+command = "npm test"


### PR DESCRIPTION
## Summary
- add tests for unauthorized, init, and profile endpoints
- ensure tests run during `npm test` and wrangler build

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd4998e094832893893dad91248af9