### PR TITLE
Bind KV to fix init API error

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,9 +2,10 @@ name = "atorvo"
 main = "worker.js"
 compatibility_date = "2024-10-01"
 
-#[[kv_namespaces]]
-#binding = "KV"
-#id = "$KV"
+[[kv_namespaces]]
+binding = "KV"
+id = "kv"
+preview_id = "kv"
 
 [assets]
 binding = "ASSETS"


### PR DESCRIPTION
## Summary
- configure `wrangler.toml` to bind the `KV` namespace so `env.KV` is available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd94ccdec48328ab454416dfb407f6