### PR TITLE
Use single KV record per persona and remove persona UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@ pre{background:#f9f9f9;padding:8px;border:1px solid #eee;border-radius:6px;white
 <nav class="nav nav-pills nav-fill sticky-top bg-light p-2" id="tabs">
 <button class="nav-link active" data-target="main">Chat</button>
 <button class="nav-link" data-target="learn">Learn</button>
-<button class="nav-link" data-target="persona">Persona</button>
 </nav>
 <section id="main" class="screen active container my-3">
 <h2>Chat</h2>
@@ -44,6 +43,7 @@ pre{background:#f9f9f9;padding:8px;border:1px solid #eee;border-radius:6px;white
   <button id="send" class="btn btn-primary">Send</button>
 </div>
 <button id="clearChat" class="btn btn-secondary">Clear</button>
+<button id="newPersona" class="btn btn-danger ms-2">New Persona</button>
 </section>
 <section id="learn" class="screen container my-3">
 <h2>Learning</h2>
@@ -51,70 +51,12 @@ pre{background:#f9f9f9;padding:8px;border:1px solid #eee;border-radius:6px;white
 <div id="qtext">Loading...</div>
 <div id="answers" class="list-group"></div>
 </section>
-<section id="persona" class="screen container my-3">
-<h2>Persona</h2>
-<input id="nameBox" class="form-control mb-2" placeholder="Persona name">
-<button id="updateName" class="btn btn-secondary mb-2">Update Name</button>
-<pre id="personaPreview"></pre>
-<textarea id="guidanceBox" rows="3" class="form-control mb-2"></textarea>
-<button id="updateGuidance" class="btn btn-primary mb-2">Update Guidance</button>
-<div>
-<button id="savePersona" class="btn btn-secondary me-2">Save</button>
-<button id="loadPersona" class="btn btn-secondary me-2">Load</button>
-<input type="file" id="loadInput" style="display:none">
-<button id="clearPersona" class="btn btn-danger">Clear</button>
-</div>
-</section>
 <script>
 if('serviceWorker' in navigator){navigator.serviceWorker.register('sw.js');}
-const defaultPersona='You are the digital twin of a real person who is ruthlessly asexual and devoid of gender or racial attributes.';
-function optimizePersonaText(text){
-  const sentences=text.split(/[\.\n]+/).map(s=>s.trim()).filter(Boolean);
-  const unique=[...new Set(sentences)];
-  return unique.map(s=>s.replace(/\s+/g,' ')).join('. ')+'.';
-}
 let personaId=localStorage.getItem('persona_id');
 if(!personaId){personaId=crypto.randomUUID();localStorage.setItem('persona_id',personaId);}
-let personaName=localStorage.getItem('persona_name')||'';
-let persona={text:defaultPersona};
-let guidanceText='';
-async function initName(){
-  if(!personaName){
-    const r=await fetch('/api/init',{method:'POST',headers:{Authorization:'Bearer '+personaId}});
-    if(r.ok){const j=await r.json();personaName=j.name;localStorage.setItem('persona_name',personaName);}
-  }
-  document.getElementById('nameBox').value=personaName;
-}
-async function loadProfile(){
-  const r=await fetch('/api/profile',{headers:{Authorization:'Bearer '+personaId}});
-  if(r.ok){const j=await r.json();persona.text=j.persona||defaultPersona;guidanceText=j.guidance||'';personaName=j.name||personaName;renderPersona();}
-}
-function renderPersona(){
-  const lines=persona.text.split('\n').slice(0,3).join('\n');
-  document.getElementById('personaPreview').textContent=lines+(persona.text.includes('\n')?'\n...':'')+(guidanceText?'\n'+guidanceText:'');
-  document.getElementById('guidanceBox').value=guidanceText;
-  document.getElementById('nameBox').value=personaName;
-}
-initName();
-loadProfile();
-document.getElementById('updateGuidance').onclick=async()=>{
-  guidanceText=document.getElementById('guidanceBox').value.trim();
-  await fetch('/api/guidance',{method:'POST',headers:{'Content-Type':'application/json',Authorization:'Bearer '+personaId},body:JSON.stringify({guidance:guidanceText})});
-  renderPersona();
-};
-document.getElementById('updateName').onclick=async()=>{
-  const nm=document.getElementById('nameBox').value.trim();
-  await fetch('/api/name',{method:'POST',headers:{'Content-Type':'application/json',Authorization:'Bearer '+personaId},body:JSON.stringify({name:nm})});
-  personaName=nm;localStorage.setItem('persona_name',personaName);
-};
-document.getElementById('savePersona').onclick=()=>{
-  const data=JSON.stringify({persona:persona.text,guidance:guidanceText},null,2);
-  const blob=new Blob([data],{type:'application/json'});
-  const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='persona.json';a.click();URL.revokeObjectURL(a.href);
-};
-document.getElementById('loadPersona').onclick=()=>document.getElementById('loadInput').click();
-document.getElementById('loadInput').onchange=e=>{const file=e.target.files[0];if(!file)return;const reader=new FileReader();reader.onload=async ev=>{try{const obj=JSON.parse(ev.target.result);persona.text=optimizePersonaText(obj.persona||defaultPersona);guidanceText=obj.guidance||'';await fetch('/api/persona',{method:'POST',headers:{'Content-Type':'application/json',Authorization:'Bearer '+personaId},body:JSON.stringify({persona:persona.text,guidance:guidanceText})});renderPersona();}catch(err){console.error(err);}};reader.readAsText(file);};
-document.getElementById('clearPersona').onclick=async()=>{persona.text=defaultPersona;guidanceText='';await fetch('/api/persona',{method:'POST',headers:{'Content-Type':'application/json',Authorization:'Bearer '+personaId},body:JSON.stringify({persona:persona.text,guidance:guidanceText})});renderPersona();};
+async function ensurePersona(){await fetch('/api/init',{method:'POST',headers:{Authorization:'Bearer '+personaId}});}
+ensurePersona();
 let chatHistory=[];
 const chatInput=document.getElementById('chatInput');
 const historyDiv=document.getElementById('history');
@@ -125,10 +67,11 @@ async function sendChat(){const q=chatInput.value.trim();if(!q)return;chatHistor
 document.getElementById('send').onclick=sendChat;document.getElementById('clearChat').onclick=()=>{chatHistory=[];renderChat();};document.querySelectorAll('.sample').forEach(b=>b.onclick=()=>{chatInput.value=b.textContent;sendChat();});
 let currentQA=null;let started=false;
 async function fetchQuestion(selected){try{const opts={headers:{Authorization:'Bearer '+personaId}};if(selected==null){opts.method='GET';}else{opts.method='POST';opts.headers['Content-Type']='application/json';opts.body=JSON.stringify({selected});}
-const r=await fetch('/api/learn',opts);const j=await r.json();currentQA=j;document.getElementById('qtext').textContent=j.question;const answersDiv=document.getElementById('answers');answersDiv.innerHTML='';j.answers.forEach((ans,i)=>{const d=document.createElement('div');d.textContent=ans;d.className='list-group-item list-group-item-action answer'+(i===j.personaIndex?' persona':'');d.onclick=()=>fetchQuestion(i);answersDiv.appendChild(d);});const confDiv=document.getElementById('confidence');confDiv.textContent='Confidence: '+j.confidence;confDiv.style.color=j.confidence==='high'?'green':j.confidence==='medium'?'orange':'red';persona.text=j.persona;renderPersona();started=true;}catch(e){document.getElementById('qtext').textContent='Error';}}
+const r=await fetch('/api/learn',opts);const j=await r.json();currentQA=j;document.getElementById('qtext').textContent=j.question;const answersDiv=document.getElementById('answers');answersDiv.innerHTML='';j.answers.forEach((ans,i)=>{const d=document.createElement('div');d.textContent=ans;d.className='list-group-item list-group-item-action answer'+(i===j.personaIndex?' persona':'');d.onclick=()=>fetchQuestion(i);answersDiv.appendChild(d);});const confDiv=document.getElementById('confidence');confDiv.textContent='Confidence: '+j.confidence;confDiv.style.color=j.confidence==='high'?'green':j.confidence==='medium'?'orange':'red';started=true;}catch(e){document.getElementById('qtext').textContent='Error';}}
 document.querySelectorAll('#tabs .nav-link').forEach(btn=>{btn.onclick=()=>showScreen(btn.dataset.target);});
 let currentScreen='main';
 function showScreen(id){currentScreen=id;document.querySelectorAll('.screen').forEach(s=>s.classList.remove('active'));document.getElementById(id).classList.add('active');document.querySelectorAll('#tabs .nav-link').forEach(b=>b.classList.remove('active'));document.querySelector(`#tabs [data-target="${id}"]`).classList.add('active');if(id==='learn'&&!started)fetchQuestion();}
+document.getElementById('newPersona').onclick=()=>{localStorage.clear();location.reload();};
 </script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/worker.js
+++ b/worker.js
@@ -1,208 +1,201 @@
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
-    if(url.pathname === '/api/init' && request.method === 'POST') {
-      const auth = request.headers.get('Authorization') || '';
-      const id = auth.startsWith('Bearer ') ? auth.slice(7) : crypto.randomUUID();
+
+    if (url.pathname === '/api/init' && request.method === 'POST') {
+      const { ok, id, code } = getId(request);
+      if (!ok) return new Response('Invalid ID', { status: code });
       return await handleInit(id, env);
     }
+
     if (request.method === 'GET') {
       if (url.pathname === '/' || url.pathname === '/index.html') {
         const asset = await env.ASSETS.fetch(new Request(url.origin + '/index.html'));
         const html = await asset.text();
-        return new Response(html, {
-          headers: { 'Content-Type': 'text/html; charset=UTF-8' }
-        });
+        return new Response(html, { headers: { 'Content-Type': 'text/html; charset=UTF-8' } });
       }
       if (url.pathname === '/sw.js') {
         const asset = await env.ASSETS.fetch(new Request(url.origin + '/sw.js'));
         const text = await asset.text();
-        return new Response(text, {
-          headers: { 'Content-Type': 'application/javascript; charset=UTF-8' }
-        });
+        return new Response(text, { headers: { 'Content-Type': 'application/javascript; charset=UTF-8' } });
       }
       if (url.pathname === '/manifest.webmanifest') {
         const asset = await env.ASSETS.fetch(new Request(url.origin + '/manifest.webmanifest'));
         const text = await asset.text();
-        return new Response(text, {
-          headers: { 'Content-Type': 'application/manifest+json; charset=UTF-8' }
-        });
+        return new Response(text, { headers: { 'Content-Type': 'application/manifest+json; charset=UTF-8' } });
       }
       if (url.pathname === '/icon.svg') {
         const asset = await env.ASSETS.fetch(new Request(url.origin + '/icon.svg'));
         const text = await asset.text();
-        return new Response(text, {
-          headers: { 'Content-Type': 'image/svg+xml; charset=UTF-8' }
-        });
+        return new Response(text, { headers: { 'Content-Type': 'image/svg+xml; charset=UTF-8' } });
       }
     }
-    const auth = request.headers.get('Authorization') || '';
-    const id = auth.startsWith('Bearer ') ? auth.slice(7) : '';
-    if(!id) return new Response('Unauthorized', {status:401});
+
+    const { ok, id, code } = getId(request);
+    if (!ok) return new Response(code === 401 ? 'Unauthorized' : 'Invalid ID', { status: code });
 
     try {
-      if(url.pathname === '/api/profile' && request.method === 'GET') {
-        return await handleProfile(id, env);
+      if (url.pathname === '/api/chat' && request.method === 'POST') {
+        const { messages = [] } = await request.json();
+        return await handleChat(id, env, messages);
       }
-      if(url.pathname === '/api/guidance' && request.method === 'POST') {
-        const {guidance=''} = await request.json();
-        await env.KV.put(`${id}-guidance`, guidance);
-        return new Response('OK');
-      }
-      if(url.pathname === '/api/name' && request.method === 'POST') {
-        const {name=''} = await request.json();
-        await env.KV.put(`${id}-name`, name);
-        return new Response('OK');
-      }
-      if(url.pathname === '/api/persona' && request.method === 'POST') {
-        const {persona, guidance} = await request.json();
-        if(persona) await env.KV.put(`${id}-persona`, optimizePersonaText(persona));
-        if(guidance !== undefined) await env.KV.put(`${id}-guidance`, guidance);
-        return new Response('OK');
-      }
-      if(url.pathname === '/api/chat' && request.method === 'POST') {
-        const {messages=[]} = await request.json();
-        const persona = (await env.KV.get(`${id}-persona`)) || defaultPersona;
-        const guidance = (await env.KV.get(`${id}-guidance`)) || '';
-        const systemMsg = {role:'system', content:`Persona:\n${persona}\nGuidance:\n${guidance}\nAnswer strictly as this persona while avoiding any mention of gender, sexuality or race. Be concise and give a clear, direct reply in one short sentence.`};
-        const [out] = await groqChat(env, [systemMsg, ...messages]);
-        return json({choices:[{message:{role:'assistant',content:out.trim()}}]});
-      }
-      if(url.pathname === '/api/learn' && request.method === 'GET') {
+      if (url.pathname === '/api/learn' && request.method === 'GET') {
         return await handleGetQuestion(id, env);
       }
-      if(url.pathname === '/api/learn' && request.method === 'POST') {
+      if (url.pathname === '/api/learn' && request.method === 'POST') {
         const body = await request.json();
         return await handleSubmitAnswer(id, env, body.selected);
       }
-      return new Response('Not found', {status:404});
-    } catch(err) {
-      return new Response(err.toString(), {status:500});
+      return new Response('Not found', { status: 404 });
+    } catch (err) {
+      return new Response(err.toString(), { status: 500 });
     }
   }
+};
+
+const defaultPersona = 'You are the digital twin of a real person who is ruthlessly asexual and devoid of gender or racial attributes.';
+
+function json(obj) {
+  return new Response(JSON.stringify(obj), { headers: { 'Content-Type': 'application/json' } });
 }
 
-const defaultPersona='You are the digital twin of a real person who is ruthlessly asexual and devoid of gender or racial attributes.';
+function isValidUUID(id) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id);
+}
 
-function json(obj){return new Response(JSON.stringify(obj),{headers:{'Content-Type':'application/json'}});}
+function getId(request) {
+  const auth = request.headers.get('Authorization') || '';
+  if (!auth.startsWith('Bearer ')) return { ok: false, code: 401 };
+  const id = auth.slice(7);
+  if (!isValidUUID(id)) return { ok: false, code: 400 };
+  return { ok: true, id };
+}
 
-async function handleInit(id, env){
-  let name = await env.KV.get(`${id}-name`);
-  if(!name){
-    const [out] = await groqChat(env,[{role:'user',content:'Give me a random name for a person that is not associated with a particular gender. Do not respond with anything other than the forename and surname.'}]);
-    name = out.trim().split(/[\n,]/)[0];
-    await env.KV.put(`${id}-name`, name);
+async function getUser(env, id) {
+  const text = await env.KV.get(id);
+  return text ? JSON.parse(text) : null;
+}
+
+async function saveUser(env, id, data) {
+  data.lastUsed = new Date().toISOString();
+  await env.KV.put(id, JSON.stringify(data));
+}
+
+async function handleInit(id, env) {
+  let data = await getUser(env, id);
+  if (!data) {
+    const [out] = await groqChat(env, [{ role: 'user', content: 'Give me a random name for a person that is not associated with a particular gender. Do not respond with anything other than the forename and surname.' }]);
+    const name = out.trim().split(/[\n,]/)[0];
+    data = { name, persona: defaultPersona, guidance: '', coverage: {}, stats: { asked: 0, correct: 0, history: [] }, pending: null };
   }
-  if(!await env.KV.get(`${id}-persona`)){
-    await env.KV.put(`${id}-persona`, defaultPersona);
-  }
-  return json({name,id});
+  await saveUser(env, id, data);
+  return json({ name: data.name, id });
 }
 
-async function handleProfile(id, env){
-  const persona = (await env.KV.get(`${id}-persona`)) || defaultPersona;
-  const guidance = (await env.KV.get(`${id}-guidance`)) || '';
-  const name = (await env.KV.get(`${id}-name`)) || '';
-  return json({persona,guidance,name});
+async function handleChat(id, env, messages) {
+  const data = await getUser(env, id);
+  if (!data) return new Response('Not found', { status: 404 });
+  const systemMsg = { role: 'system', content: `Persona:\n${data.persona}\nGuidance:\n${data.guidance}\nAnswer strictly as this persona while avoiding any mention of gender, sexuality or race. Be concise and give a clear, direct reply in one short sentence.` };
+  const [out] = await groqChat(env, [systemMsg, ...messages]);
+  await saveUser(env, id, data);
+  return json({ choices: [{ message: { role: 'assistant', content: out.trim() } }] });
 }
 
-function optimizePersonaText(text){
-  const sentences=text.split(/[\.\n]+/).map(s=>s.trim()).filter(Boolean);
-  const unique=[...new Set(sentences)];
-  return unique.map(s=>s.replace(/\s+/g,' ')).join('. ')+'.';
+async function handleGetQuestion(id, env) {
+  const data = await getUser(env, id);
+  if (!data) return new Response('Not found', { status: 404 });
+  const qa = await generateQuestion(env, data);
+  data.pending = qa;
+  await saveUser(env, id, data);
+  const confidence = computeConfidence(data.stats.history);
+  return json({ ...qa, confidence });
 }
 
-async function groqChat(env, messages){
+async function handleSubmitAnswer(id, env, selected) {
+  const data = await getUser(env, id);
+  if (!data) return new Response('Not found', { status: 404 });
+  const pending = data.pending;
+  if (!pending) return new Response('No question', { status: 400 });
+  const answer = pending.answers[selected];
+  const prompt = `Existing persona:\n${data.persona}\nGuidance:\n${data.guidance}\nQuestion:${pending.question}\nCategory:${pending.category}\nAnswers:${pending.answers.join(' | ')}\nUser selected:${answer}. Revise the persona incrementally so it leans toward this option while avoiding assumptions about name, gender, sexuality, or race. Ensure the persona remains ruthlessly asexual, concise and non-redundant. Reply with the updated persona text only.`;
+  const [out] = await groqChat(env, [{ role: 'user', content: prompt }]);
+  const newPersona = optimizePersonaText(out.trim());
+  data.persona = newPersona;
+  data.coverage[pending.category] = (data.coverage[pending.category] || 0) + 1;
+  const correct = selected === pending.personaIndex;
+  data.stats.asked++;
+  if (correct) data.stats.correct++;
+  data.stats.history.push(correct);
+  if (data.stats.history.length > 10) data.stats.history.splice(0, data.stats.history.length - 10);
+  const qa = await generateQuestion(env, data);
+  data.pending = qa;
+  await saveUser(env, id, data);
+  const confidence = computeConfidence(data.stats.history);
+  return json({ ...qa, confidence });
+}
+
+function optimizePersonaText(text) {
+  const sentences = text.split(/[\.\n]+/).map(s => s.trim()).filter(Boolean);
+  const unique = [...new Set(sentences)];
+  return unique.map(s => s.replace(/\s+/g, ' ')).join('. ') + '.';
+}
+
+async function groqChat(env, messages) {
   const key = await env.KV.get('groq-api-key');
-  if(!key) throw new Error('Missing API key');
-  const r = await fetch('https://api.groq.com/openai/v1/chat/completions',{
-    method:'POST',
-    headers:{'Content-Type':'application/json','Authorization':'Bearer '+key},
-    body:JSON.stringify({model:'llama-3.1-8b-instant',temperature:0.7,messages})
+  if (!key) throw new Error('Missing API key');
+  const r = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + key },
+    body: JSON.stringify({ model: 'llama-3.1-8b-instant', temperature: 0.7, messages })
   });
   const text = await r.text();
-  if(!r.ok) throw new Error(text);
+  if (!r.ok) throw new Error(text);
   const j = JSON.parse(text);
-  return (j.choices||[]).map(c=>c.message?.content).filter(Boolean);
+  return (j.choices || []).map(c => c.message?.content).filter(Boolean);
 }
 
-const categories=[
-  {name:'Likes & Dislikes',desc:'tastes in activities or food'},
-  {name:'Politics & Society',desc:'political and social outlook'},
-  {name:'Geography & Climate',desc:'preferred places and weather'},
-  {name:'Energy & Routine',desc:'daily energy and lifestyle'},
-  {name:'Aspirations & Goals',desc:'career or life ambitions'},
-  {name:'Psychological Traits',desc:'thinking patterns and behaviour'},
-  {name:'Culture & Arts',desc:'music, media and art interests'},
-  {name:'Relationships & Community',desc:'friendships and social ties'},
-  {name:'Work & Productivity',desc:'discipline and work style'},
-  {name:'Decision Making & Values',desc:'how choices and priorities form'},
-  {name:'Emotions & Coping',desc:'responses to stress or loss'},
-  {name:'Technology & Innovation',desc:'attitude toward new tech'},
-  {name:'Spare Time & Hobbies',desc:'weekend and leisure pursuits'},
-  {name:'Financial Outlook',desc:'saving, spending or investing'},
-  {name:'Travel & Adventure',desc:'motivation for exploring new places'}
+const categories = [
+  { name: 'Likes & Dislikes', desc: 'tastes in activities or food' },
+  { name: 'Politics & Society', desc: 'political and social outlook' },
+  { name: 'Geography & Climate', desc: 'preferred places and weather' },
+  { name: 'Energy & Routine', desc: 'daily energy and lifestyle' },
+  { name: 'Aspirations & Goals', desc: 'career or life ambitions' },
+  { name: 'Psychological Traits', desc: 'thinking patterns and behaviour' },
+  { name: 'Culture & Arts', desc: 'music, media and art interests' },
+  { name: 'Relationships & Community', desc: 'friendships and social ties' },
+  { name: 'Work & Productivity', desc: 'discipline and work style' },
+  { name: 'Decision Making & Values', desc: 'how choices and priorities form' },
+  { name: 'Emotions & Coping', desc: 'responses to stress or loss' },
+  { name: 'Technology & Innovation', desc: 'attitude toward new tech' },
+  { name: 'Spare Time & Hobbies', desc: 'weekend and leisure pursuits' },
+  { name: 'Financial Outlook', desc: 'saving, spending or investing' },
+  { name: 'Travel & Adventure', desc: 'motivation for exploring new places' }
 ];
 
-function leastCovered(coverage){
-  let min=Infinity, opts=[];
-  for(const c of categories){
-    const v=coverage[c.name]||0;
-    if(v<min){min=v;opts=[c];}
-    else if(v===min){opts.push(c);}
+function leastCovered(coverage) {
+  let min = Infinity, opts = [];
+  for (const c of categories) {
+    const v = coverage[c.name] || 0;
+    if (v < min) { min = v; opts = [c]; }
+    else if (v === min) { opts.push(c); }
   }
-  return opts[Math.floor(Math.random()*opts.length)];
+  return opts[Math.floor(Math.random() * opts.length)];
 }
 
-function computeConfidence(stats){
-  if(stats.length<10) return 'low';
-  const wrong = stats.filter(v=>!v).length;
-  if(wrong===0) return 'high';
-  if(wrong>3) return 'low';
+function computeConfidence(history) {
+  if (history.length < 10) return 'low';
+  const wrong = history.filter(v => !v).length;
+  if (wrong === 0) return 'high';
+  if (wrong > 3) return 'low';
   return 'medium';
 }
 
-async function generateQuestion(id, env, persona, guidance, coverage){
-  const cat = leastCovered(coverage);
-  const prompt=`Persona:\n${persona}\nGuidance:\n${guidance}\n\nGenerate one concise multiple-choice question (<=15 words) about this persona's ${cat.name} (${cat.desc}). Provide two to four brief answers (<=6 words) that are mutually exclusive and collectively exhaustive. Do not include 'not applicable' or similar options and avoid any reference to gender, sexuality or race. Only repeat a topic to clarify ambiguity. Return JSON {question:string, answers:string[], personaIndex:number}.`;
-  const [out]=await groqChat(env,[{role:'user',content:prompt}]);
-  const match=out.match(/\{[\s\S]*\}/);
-  const cleaned=match[0].replace(/\/\/.*$/gm,'').replace(/\/\*[\s\S]*?\*\//g,'');
-  const qa=JSON.parse(cleaned);
-  const pending={question:qa.question,answers:qa.answers,personaIndex:qa.personaIndex,category:cat.name};
-  await env.KV.put(`${id}-pending`, JSON.stringify(pending));
-  return pending;
+async function generateQuestion(env, data) {
+  const cat = leastCovered(data.coverage);
+  const prompt = `Persona:\n${data.persona}\nGuidance:\n${data.guidance}\n\nGenerate one concise multiple-choice question (<=15 words) about this persona's ${cat.name} (${cat.desc}). Provide two to four brief answers (<=6 words) that are mutually exclusive and collectively exhaustive. Do not include 'not applicable' or similar options and avoid any reference to gender, sexuality or race. Only repeat a topic to clarify ambiguity. Return JSON {question:string, answers:string[], personaIndex:number}.`;
+  const [out] = await groqChat(env, [{ role: 'user', content: prompt }]);
+  const match = out.match(/\{[\s\S]*\}/);
+  const cleaned = match[0].replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+  const qa = JSON.parse(cleaned);
+  return { question: qa.question, answers: qa.answers, personaIndex: qa.personaIndex, category: cat.name };
 }
-
-async function handleGetQuestion(id, env){
-  const persona=(await env.KV.get(`${id}-persona`))||defaultPersona;
-  const guidance=(await env.KV.get(`${id}-guidance`))||'';
-  const coverage=JSON.parse(await env.KV.get(`${id}-coverage`)||'{}');
-  const stats=JSON.parse(await env.KV.get(`${id}-stats`)||'[]');
-  const qa=await generateQuestion(id, env, persona, guidance, coverage);
-  const confidence=computeConfidence(stats);
-  return json({...qa, confidence, persona});
-}
-
-async function handleSubmitAnswer(id, env, selected){
-  const persona=(await env.KV.get(`${id}-persona`))||defaultPersona;
-  const guidance=(await env.KV.get(`${id}-guidance`))||'';
-  const pending=JSON.parse(await env.KV.get(`${id}-pending`)||'null');
-  if(!pending) return new Response('No question', {status:400});
-  const coverage=JSON.parse(await env.KV.get(`${id}-coverage`)||'{}');
-  const stats=JSON.parse(await env.KV.get(`${id}-stats`)||'[]');
-  const answer=pending.answers[selected];
-  const prompt=`Existing persona:\n${persona}\nGuidance:\n${guidance}\nQuestion:${pending.question}\nCategory:${pending.category}\nAnswers:${pending.answers.join(' | ')}\nUser selected:${answer}. Revise the persona incrementally so it leans toward this option while avoiding assumptions about name, gender, sexuality, or race. Ensure the persona remains ruthlessly asexual, concise and non-redundant. Reply with the updated persona text only.`;
-  const [out]=await groqChat(env,[{role:'user',content:prompt}]);
-  const newPersona=optimizePersonaText(out.trim());
-  await env.KV.put(`${id}-persona`, newPersona);
-  coverage[pending.category]=(coverage[pending.category]||0)+1;
-  await env.KV.put(`${id}-coverage`, JSON.stringify(coverage));
-  const correct = selected===pending.personaIndex;
-  stats.push(correct); if(stats.length>10) stats.splice(0,stats.length-10);
-  await env.KV.put(`${id}-stats`, JSON.stringify(stats));
-  const qa=await generateQuestion(id, env, newPersona, guidance, coverage);
-  const confidence=computeConfidence(stats);
-  return json({...qa, confidence, persona:newPersona});
-}
-

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@ main = "worker.js"
 compatibility_date = "2024-10-01"
 
 kv_namespaces = [
-  { binding = "KV", id = "atorvo" }
+  { binding = "atorvo", id = "KV" }
 ]
 
 [assets]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@ main = "worker.js"
 compatibility_date = "2024-10-01"
 
 kv_namespaces = [
-  { binding = "atorvo", id = "KV" }
+  { binding = "KV", id = "ac197a3f5a6d4f82b5586970f780beeb" }
 ]
 
 [assets]


### PR DESCRIPTION
## Summary
- Store all persona data in a single KV entry keyed by a UUID from the Authorization header
- Validate bearer token as UUID and track `lastUsed` timestamp with per-user stats
- Simplify UI by removing persona screen and adding a client-side reset button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc81590c48328950217ab92bf2ab7