### PR TITLE
Add admin route that authenticates with env credentials

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -1,0 +1,31 @@
+const BASIC_AUTH_HEADER = 'Basic ';
+
+function decodeBase64(value) {
+  if (typeof atob === 'function') return atob(value);
+  if (typeof Buffer !== 'undefined') return Buffer.from(value, 'base64').toString('utf8');
+  throw new Error('No base64 decoder available');
+}
+
+export async function handleAdmin(request, env) {
+  const username = env.ADMIN_USERNAME;
+  const password = env.ADMIN_PASSWORD;
+  if (!username || !password) {
+    return new Response('Admin credentials not configured', { status: 500 });
+  }
+
+  const auth = request.headers.get('Authorization') || '';
+  if (!auth.startsWith(BASIC_AUTH_HEADER)) {
+    return new Response('Missing Authorization', {
+      status: 401,
+      headers: { 'WWW-Authenticate': 'Basic realm="admin", charset="UTF-8"' }
+    });
+  }
+
+  const decoded = decodeBase64(auth.slice(BASIC_AUTH_HEADER.length));
+  const [user, pass] = decoded.split(':');
+  if (user !== username || pass !== password) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  return new Response('Admin OK', { status: 200 });
+}

--- a/worker.js
+++ b/worker.js
@@ -1,3 +1,5 @@
+import { handleAdmin } from './admin.js';
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -28,6 +30,9 @@ export default {
         const asset = await env.ASSETS.fetch(new Request(url.origin + '/icon.svg'));
         const text = await asset.text();
         return new Response(text, { headers: { 'Content-Type': 'image/svg+xml; charset=UTF-8' } });
+      }
+      if (url.pathname === '/admin') {
+        return await handleAdmin(request, env);
       }
     }
 

--- a/worker.test.js
+++ b/worker.test.js
@@ -67,3 +67,31 @@ test('GET / returns index.html', async () => {
   const text = await res.text();
   assert.ok(text.includes('<title>Persona Trainer PWA</title>'));
 });
+
+test('GET /admin requires credentials and reads env vars', async () => {
+  const kv = new MockKV();
+  const env = { KV: kv, ADMIN_USERNAME: 'admin', ADMIN_PASSWORD: 'secret' };
+
+  const reqMissing = new Request('http://example.com/admin');
+  let res = await worker.fetch(reqMissing, env);
+  assert.equal(res.status, 401);
+
+  const badAuth = 'Basic ' + Buffer.from('admin:wrong').toString('base64');
+  res = await worker.fetch(new Request('http://example.com/admin', { headers: { Authorization: badAuth } }), env);
+  assert.equal(res.status, 403);
+
+  const goodAuth = 'Basic ' + Buffer.from('admin:secret').toString('base64');
+  res = await worker.fetch(new Request('http://example.com/admin', { headers: { Authorization: goodAuth } }), env);
+  assert.equal(res.status, 200);
+  const text = await res.text();
+  assert.equal(text, 'Admin OK');
+});
+
+test('GET /admin reports missing env vars', async () => {
+  const env = { KV: new MockKV() };
+  const req = new Request('http://example.com/admin');
+  const res = await worker.fetch(req, env);
+  assert.equal(res.status, 500);
+  const text = await res.text();
+  assert.equal(text, 'Admin credentials not configured');
+});


### PR DESCRIPTION
## Summary
- add a dedicated /admin handler that uses Cloudflare environment bindings for credentials
- implement base64 decoding that works in both Workers and Node test environments
- cover admin authentication success and failure scenarios with tests

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d849caa608328bed7f18de784a6a3)